### PR TITLE
Modified deviceId to return value also for tablets

### DIFF
--- a/Acr.MvvmCross.Plugins.DeviceInfo.Droid/DroidDeviceInfoService.cs
+++ b/Acr.MvvmCross.Plugins.DeviceInfo.Droid/DroidDeviceInfoService.cs
@@ -4,6 +4,7 @@ using Android.Content;
 using Android.Content.PM;
 using Android.Content.Res;
 using Android.Telephony;
+using Android.Provider;
 using B = Android.OS.Build;
 
 
@@ -31,7 +32,8 @@ namespace Acr.MvvmCross.Plugins.DeviceInfo.Droid {
             });
             this.deviceId = new Lazy<string>(() => {
                 var tel = (TelephonyManager)Application.Context.ApplicationContext.GetSystemService(Context.TelephonyService);
-                return tel.DeviceId;
+				// Returns DeviceId from TelephonyManager for phones or AndroidId from Settings.Secure for tablets
+				return tel.DeviceId ?? Settings.Secure.GetString(Application.Context.ApplicationContext.ContentResolver, Settings.Secure.AndroidId);
             });
         }
 


### PR DESCRIPTION
Changed to reflect the following solution...
http://stackoverflow.com/questions/3802644/will-telephonymanger-getdeviceid-return-device-id-for-tablets-like-galaxy-tab#8145184
