### PR TITLE
Make SetInputType protected

### DIFF
--- a/Acr.MvvmCross.Plugins.UserDialogs.Droid/DroidUserDialogService.cs
+++ b/Acr.MvvmCross.Plugins.UserDialogs.Droid/DroidUserDialogService.cs
@@ -127,7 +127,7 @@ namespace Acr.MvvmCross.Plugins.UserDialogs.Droid {
             });
         }
 
-        private static void SetInputType(TextView txt, InputType inputType) {
+        protected static void SetInputType(TextView txt, InputType inputType) {
             switch (inputType) {
                 case InputType.Email:
                     txt.InputType = InputTypes.TextVariationEmailAddress;


### PR DESCRIPTION
I wanted to override Prompt() with the single change of setting margins on the textview. However, I could not call SetInputType in my subclass, as it is private. Making it protected will take care of that.